### PR TITLE
feat(frontend): HTMX container list, create form, and detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ For in-depth information on the design, see [docs/architecture.md](docs/architec
 
 📋 **Next (Milestone 3+):**
 - [ ] Complete all remaining profiles (clang:riscv, node, electron, blender, comfyui, agents)
-- [ ] Build frontend UI (container list, create form, detail page)
+- [x] Build frontend UI (container list, create form, detail page)
 - [ ] Add ttyd/code-server proxying
 - [ ] Add log streaming endpoint (Server-Sent Events)
 - [ ] End-to-end testing on real LXD host

--- a/backend/app/api/ui.py
+++ b/backend/app/api/ui.py
@@ -1,0 +1,394 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import ValidationError
+
+from app.api.deps import get_lxd_service, get_registry, get_store
+from app.api.containers import _write_secrets
+from app.config import get_settings
+from app.lxd.container_init import build_user_data
+from app.lxd.containers import LXDContainerService
+from app.profiles.registry import ProfileRegistry
+from app.profiles.resolver import ProfileResolver
+from app.schemas import CreateContainerRequest
+from app.store.json_store import JsonStore
+from app.store.models import ContainerRecord
+
+router = APIRouter(tags=["ui"])
+templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+
+def _form_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.lower() in {"1", "true", "on", "yes"}
+
+
+def _parse_secrets(raw: str) -> dict[str, str]:
+    secrets: dict[str, str] = {}
+    for line in raw.splitlines():
+        entry = line.strip()
+        if not entry or "=" not in entry:
+            continue
+        key, value = entry.split("=", maxsplit=1)
+        key = key.strip()
+        if key:
+            secrets[key] = value.strip()
+    return secrets
+
+
+def _profile_options(registry: ProfileRegistry, category: str) -> list[dict[str, str]]:
+    profiles = registry.load_all().values()
+    scoped = [profile for profile in profiles if profile.category == category]
+    return [
+        {
+            "value": profile.name,
+            "slug": profile.name.split("/", maxsplit=1)[1],
+            "label": profile.name,
+        }
+        for profile in sorted(scoped, key=lambda item: item.name)
+    ]
+
+
+async def _with_status(record: ContainerRecord, lxd: LXDContainerService, store: JsonStore) -> ContainerRecord:
+    try:
+        record.status = await lxd.get_status(record.name)
+        store.upsert(record)
+    except Exception:  # noqa: BLE001
+        record.status = "error"
+    return record
+
+
+async def _all_records(store: JsonStore, lxd: LXDContainerService) -> list[ContainerRecord]:
+    records = list(store.load().values())
+    records.sort(key=lambda item: item.name)
+    results: list[ContainerRecord] = []
+    for record in records:
+        results.append(await _with_status(record, lxd, store))
+    return results
+
+
+@router.get("/", response_class=HTMLResponse)
+async def dashboard(
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    records = await _all_records(store, lxd)
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "records": records,
+        },
+    )
+
+
+@router.get("/create", response_class=HTMLResponse)
+async def create_page(
+    request: Request,
+    registry: ProfileRegistry = Depends(get_registry),
+) -> HTMLResponse:
+    use_cases = _profile_options(registry, "use-case")
+    tools = _profile_options(registry, "tool")
+    agents = _profile_options(registry, "agent")
+    services = _profile_options(registry, "service")
+
+    return templates.TemplateResponse(
+        "create.html",
+        {
+            "request": request,
+            "use_cases": use_cases,
+            "tools": tools,
+            "agents": agents,
+            "services": services,
+        },
+    )
+
+
+@router.get("/containers/{name}", response_class=HTMLResponse)
+async def container_detail_page(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    snapshots = await lxd.list_snapshots(name)
+    record = await _with_status(record, lxd, store)
+
+    return templates.TemplateResponse(
+        "container.html",
+        {
+            "request": request,
+            "container": record,
+            "snapshots": snapshots,
+        },
+    )
+
+
+@router.get("/fragments/containers", response_class=HTMLResponse)
+async def containers_fragment(
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    records = await _all_records(store, lxd)
+    return templates.TemplateResponse(
+        "fragments/container_list.html",
+        {"request": request, "records": records},
+    )
+
+
+@router.post("/fragments/containers/create")
+async def create_container_from_form(
+    request: Request,
+    name: str = Form(...),
+    profile_string: str = Form(...),
+    ephemeral: str | None = Form(default=None),
+    cpu_limit: int = Form(default=2),
+    memory_limit_gb: int = Form(default=4),
+    enable_gpu: str | None = Form(default=None),
+    secrets_text: str = Form(default=""),
+    store: JsonStore = Depends(get_store),
+    registry: ProfileRegistry = Depends(get_registry),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    if store.get(name):
+        return templates.TemplateResponse(
+            "fragments/create_result.html",
+            {
+                "request": request,
+                "success": False,
+                "message": "Container already exists.",
+            },
+            status_code=status.HTTP_409_CONFLICT,
+        )
+
+    secrets = _parse_secrets(secrets_text)
+    try:
+        body = CreateContainerRequest(
+            name=name,
+            profile_string=profile_string,
+            ephemeral=_form_bool(ephemeral),
+            cpu_limit=cpu_limit,
+            memory_limit_gb=memory_limit_gb,
+            enable_gpu=_form_bool(enable_gpu),
+            secrets=secrets,
+        )
+    except ValidationError as exc:
+        message = "; ".join(err["msg"] for err in exc.errors())
+        return templates.TemplateResponse(
+            "fragments/create_result.html",
+            {
+                "request": request,
+                "success": False,
+                "message": message,
+            },
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+
+    resolver = ProfileResolver(registry.load_all())
+    try:
+        resolved_profiles = resolver.resolve_from_string(body.profile_string)
+    except ValueError as exc:
+        return templates.TemplateResponse(
+            "fragments/create_result.html",
+            {
+                "request": request,
+                "success": False,
+                "message": str(exc),
+            },
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+
+    user_data = build_user_data(body.profile_string, resolved_profiles, registry)
+    settings = get_settings()
+    workspace_path = settings.workspaces_dir / body.name
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    _write_secrets(body.name, body.secrets, settings.secrets_dir)
+
+    lxd_config = {
+        "limits.cpu": str(body.cpu_limit),
+        "limits.memory": f"{body.memory_limit_gb}GB",
+    }
+
+    await lxd.create_container(body.name, resolved_profiles, user_data, lxd_config)
+
+    record = ContainerRecord(
+        name=body.name,
+        profile_string=body.profile_string,
+        resolved_profiles=resolved_profiles,
+        ephemeral=body.ephemeral,
+        gpu_enabled=body.enable_gpu,
+        created_at=datetime.now(UTC),
+        last_used=None,
+        status="starting",
+        workspace_path=str(workspace_path),
+    )
+    store.upsert(record)
+
+    if request.headers.get("HX-Request") == "true":
+        return HTMLResponse(
+            "",
+            status_code=status.HTTP_201_CREATED,
+            headers={"HX-Redirect": f"/containers/{body.name}"},
+        )
+    return RedirectResponse(url=f"/containers/{body.name}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/fragments/containers/{name}/start", response_class=HTMLResponse)
+async def start_container_from_ui(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.start_container(name)
+    record.status = "running"
+    record.last_used = datetime.now(UTC)
+    store.upsert(record)
+
+    return templates.TemplateResponse(
+        "fragments/container_row.html",
+        {
+            "request": request,
+            "container": record,
+        },
+    )
+
+
+@router.post("/fragments/containers/{name}/stop", response_class=HTMLResponse)
+async def stop_container_from_ui(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.stop_container(name)
+    record.status = "stopped"
+    store.upsert(record)
+
+    if record.ephemeral:
+        await lxd.delete_container(name)
+        store.delete(name)
+        return HTMLResponse("")
+
+    return templates.TemplateResponse(
+        "fragments/container_row.html",
+        {
+            "request": request,
+            "container": record,
+        },
+    )
+
+
+@router.delete("/fragments/containers/{name}")
+async def delete_container_from_ui(
+    name: str,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.delete_container(name)
+    store.delete(name)
+    return HTMLResponse("")
+
+
+@router.get("/fragments/containers/{name}/status", response_class=HTMLResponse)
+async def container_status_fragment(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    record = await _with_status(record, lxd, store)
+    return templates.TemplateResponse(
+        "fragments/status_badge.html",
+        {
+            "request": request,
+            "status": record.status,
+        },
+    )
+
+
+@router.get("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
+async def snapshots_fragment(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    snapshots = await lxd.list_snapshots(name)
+    return templates.TemplateResponse(
+        "fragments/snapshot_list.html",
+        {
+            "request": request,
+            "name": name,
+            "snapshots": snapshots,
+        },
+    )
+
+
+@router.post("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
+async def create_snapshot_from_ui(
+    name: str,
+    request: Request,
+    snapshot_name: str = Form(...),
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.create_snapshot(name, snapshot_name)
+    snapshots = await lxd.list_snapshots(name)
+    return templates.TemplateResponse(
+        "fragments/snapshot_list.html",
+        {
+            "request": request,
+            "name": name,
+            "snapshots": snapshots,
+        },
+    )
+
+
+@router.post("/fragments/containers/{name}/snapshots/{snapshot}/restore")
+async def restore_snapshot_from_ui(
+    name: str,
+    snapshot: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.restore_snapshot(name, snapshot)
+    if request.headers.get("HX-Request") == "true":
+        return HTMLResponse("", headers={"HX-Trigger": "snapshot-restored"})
+    return RedirectResponse(url=f"/containers/{name}", status_code=status.HTTP_303_SEE_OTHER)

--- a/backend/app/api/ui.py
+++ b/backend/app/api/ui.py
@@ -78,13 +78,7 @@ async def dashboard(
     lxd: LXDContainerService = Depends(get_lxd_service),
 ) -> HTMLResponse:
     records = await _all_records(store, lxd)
-    return templates.TemplateResponse(
-        "index.html",
-        {
-            "request": request,
-            "records": records,
-        },
-    )
+    return templates.TemplateResponse(request, "index.html", {"records": records})
 
 
 @router.get("/create", response_class=HTMLResponse)
@@ -97,16 +91,12 @@ async def create_page(
     agents = _profile_options(registry, "agent")
     services = _profile_options(registry, "service")
 
-    return templates.TemplateResponse(
-        "create.html",
-        {
-            "request": request,
-            "use_cases": use_cases,
-            "tools": tools,
-            "agents": agents,
-            "services": services,
-        },
-    )
+    return templates.TemplateResponse(request, "create.html", {
+        "use_cases": use_cases,
+        "tools": tools,
+        "agents": agents,
+        "services": services,
+    })
 
 
 @router.get("/containers/{name}", response_class=HTMLResponse)
@@ -123,14 +113,7 @@ async def container_detail_page(
     snapshots = await lxd.list_snapshots(name)
     record = await _with_status(record, lxd, store)
 
-    return templates.TemplateResponse(
-        "container.html",
-        {
-            "request": request,
-            "container": record,
-            "snapshots": snapshots,
-        },
-    )
+    return templates.TemplateResponse(request, "container.html", {"container": record, "snapshots": snapshots})
 
 
 @router.get("/fragments/containers", response_class=HTMLResponse)
@@ -140,10 +123,7 @@ async def containers_fragment(
     lxd: LXDContainerService = Depends(get_lxd_service),
 ) -> HTMLResponse:
     records = await _all_records(store, lxd)
-    return templates.TemplateResponse(
-        "fragments/container_list.html",
-        {"request": request, "records": records},
-    )
+    return templates.TemplateResponse(request, "fragments/container_list.html", {"records": records})
 
 
 @router.post("/fragments/containers/create")
@@ -162,12 +142,9 @@ async def create_container_from_form(
 ) -> Response:
     if store.get(name):
         return templates.TemplateResponse(
+            request,
             "fragments/create_result.html",
-            {
-                "request": request,
-                "success": False,
-                "message": "Container already exists.",
-            },
+            {"success": False, "message": "Container already exists."},
             status_code=status.HTTP_409_CONFLICT,
         )
 
@@ -185,12 +162,9 @@ async def create_container_from_form(
     except ValidationError as exc:
         message = "; ".join(err["msg"] for err in exc.errors())
         return templates.TemplateResponse(
+            request,
             "fragments/create_result.html",
-            {
-                "request": request,
-                "success": False,
-                "message": message,
-            },
+            {"success": False, "message": message},
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
 
@@ -199,12 +173,9 @@ async def create_container_from_form(
         resolved_profiles = resolver.resolve_from_string(body.profile_string)
     except ValueError as exc:
         return templates.TemplateResponse(
+            request,
             "fragments/create_result.html",
-            {
-                "request": request,
-                "success": False,
-                "message": str(exc),
-            },
+            {"success": False, "message": str(exc)},
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
 
@@ -259,13 +230,7 @@ async def start_container_from_ui(
     record.last_used = datetime.now(UTC)
     store.upsert(record)
 
-    return templates.TemplateResponse(
-        "fragments/container_row.html",
-        {
-            "request": request,
-            "container": record,
-        },
-    )
+    return templates.TemplateResponse(request, "fragments/container_row.html", {"container": record})
 
 
 @router.post("/fragments/containers/{name}/stop", response_class=HTMLResponse)
@@ -288,13 +253,7 @@ async def stop_container_from_ui(
         store.delete(name)
         return HTMLResponse("")
 
-    return templates.TemplateResponse(
-        "fragments/container_row.html",
-        {
-            "request": request,
-            "container": record,
-        },
-    )
+    return templates.TemplateResponse(request, "fragments/container_row.html", {"container": record})
 
 
 @router.delete("/fragments/containers/{name}")
@@ -324,13 +283,7 @@ async def container_status_fragment(
         raise HTTPException(status_code=404, detail="container not found")
 
     record = await _with_status(record, lxd, store)
-    return templates.TemplateResponse(
-        "fragments/status_badge.html",
-        {
-            "request": request,
-            "status": record.status,
-        },
-    )
+    return templates.TemplateResponse(request, "fragments/status_badge.html", {"status": record.status})
 
 
 @router.get("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
@@ -344,14 +297,7 @@ async def snapshots_fragment(
         raise HTTPException(status_code=404, detail="container not found")
 
     snapshots = await lxd.list_snapshots(name)
-    return templates.TemplateResponse(
-        "fragments/snapshot_list.html",
-        {
-            "request": request,
-            "name": name,
-            "snapshots": snapshots,
-        },
-    )
+    return templates.TemplateResponse(request, "fragments/snapshot_list.html", {"name": name, "snapshots": snapshots})
 
 
 @router.post("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
@@ -367,14 +313,7 @@ async def create_snapshot_from_ui(
 
     await lxd.create_snapshot(name, snapshot_name)
     snapshots = await lxd.list_snapshots(name)
-    return templates.TemplateResponse(
-        "fragments/snapshot_list.html",
-        {
-            "request": request,
-            "name": name,
-            "snapshots": snapshots,
-        },
-    )
+    return templates.TemplateResponse(request, "fragments/snapshot_list.html", {"name": name, "snapshots": snapshots})
 
 
 @router.post("/fragments/containers/{name}/snapshots/{snapshot}/restore")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,13 @@ from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 
 from app.api.containers import router as containers_router
 from app.api.health import router as health_router
 from app.api.profiles import router as profiles_router
+from app.api.ui import router as ui_router
 from app.config import get_settings
 
 
@@ -27,11 +26,5 @@ app = FastAPI(title="YETAOS", version="0.1.0", lifespan=lifespan)
 app.include_router(health_router)
 app.include_router(profiles_router)
 app.include_router(containers_router)
-
-templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+app.include_router(ui_router)
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
-
-
-@app.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse("index.html", {"request": request})

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -4,14 +4,252 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>YETAOS</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
+    <script src="https://unpkg.com/alpinejs@3.14.9/dist/cdn.min.js" defer></script>
     <style>
-      :root { color-scheme: light; }
-      body { font-family: "IBM Plex Sans", sans-serif; margin: 0; background: linear-gradient(140deg, #eef7ff, #f8fff0); }
-      main { max-width: 980px; margin: 0 auto; padding: 24px; }
-      .card { background: #fff; border: 1px solid #d7e4ef; border-radius: 12px; padding: 16px; }
+      :root {
+        color-scheme: light;
+        --ink: #1f2933;
+        --soft-ink: #52606d;
+        --surface: #ffffff;
+        --line: #d9e2ec;
+        --accent: #006d77;
+        --accent-2: #f4a261;
+        --ok: #2f9e44;
+        --warn: #b75d0a;
+        --bad: #c92a2a;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: "IBM Plex Sans", sans-serif;
+        margin: 0;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at 15% 20%, rgba(244, 162, 97, 0.25), transparent 36%),
+          radial-gradient(circle at 85% 10%, rgba(0, 109, 119, 0.2), transparent 44%),
+          linear-gradient(160deg, #f5fbff 0%, #f9fff8 100%);
+      }
+
+      nav {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+        backdrop-filter: blur(6px);
+        background: rgba(255, 255, 255, 0.72);
+      }
+
+      .nav-inner {
+        max-width: 1100px;
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 14px 24px;
+      }
+
+      .brand {
+        font-family: "IBM Plex Mono", monospace;
+        font-weight: 600;
+        text-decoration: none;
+        color: var(--ink);
+        letter-spacing: 0.02em;
+      }
+
+      .nav-links {
+        display: flex;
+        gap: 12px;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 20px 24px 36px;
+      }
+
+      .panel {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 18px;
+        box-shadow: 0 12px 40px rgba(31, 41, 51, 0.06);
+      }
+
+      .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .muted {
+        color: var(--soft-ink);
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        padding: 8px 12px;
+        text-decoration: none;
+        color: var(--ink);
+        background: #fff;
+        font-size: 0.92rem;
+      }
+
+      .button.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+
+      .button.warn {
+        background: #fff8f0;
+        border-color: #ffd6a5;
+        color: var(--warn);
+      }
+
+      .button.bad {
+        background: #fff5f5;
+        border-color: #ffc9c9;
+        color: var(--bad);
+      }
+
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 999px;
+        padding: 4px 10px;
+        font-size: 0.8rem;
+        font-weight: 600;
+      }
+
+      .status.running {
+        background: #ebfbee;
+        color: var(--ok);
+      }
+
+      .status.starting {
+        background: #fff9db;
+        color: #9c6f00;
+      }
+
+      .status.stopped {
+        background: #f1f3f5;
+        color: #495057;
+      }
+
+      .status.error {
+        background: #fff5f5;
+        color: var(--bad);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        padding: 12px 8px;
+        vertical-align: top;
+      }
+
+      th {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--soft-ink);
+      }
+
+      input,
+      textarea,
+      select {
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 8px 10px;
+        font: inherit;
+        background: #fff;
+      }
+
+      .field-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .note-ok {
+        border: 1px solid #b2f2bb;
+        background: #ebfbee;
+        border-radius: 10px;
+        padding: 10px;
+      }
+
+      .note-error {
+        border: 1px solid #ffc9c9;
+        background: #fff5f5;
+        border-radius: 10px;
+        padding: 10px;
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding: 14px;
+        }
+
+        .field-grid {
+          grid-template-columns: 1fr;
+        }
+
+        table,
+        thead,
+        tbody,
+        tr,
+        th,
+        td {
+          display: block;
+        }
+
+        thead {
+          display: none;
+        }
+
+        tr {
+          padding: 10px 0;
+          border-bottom: 1px solid var(--line);
+        }
+
+        td {
+          border: none;
+          padding: 4px 0;
+        }
+      }
     </style>
   </head>
   <body>
+    <nav>
+      <div class="nav-inner">
+        <a class="brand" href="/">YETAOS / DEV ORCHESTRATOR</a>
+        <div class="nav-links">
+          <a class="button" href="/">Dashboard</a>
+          <a class="button primary" href="/create">New Environment</a>
+        </div>
+      </div>
+    </nav>
     <main>
       {% block content %}{% endblock %}
     </main>

--- a/backend/app/templates/container.html
+++ b/backend/app/templates/container.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="panel">
+  <div class="row">
+    <div>
+      <h1 style="margin: 0 0 6px">{{ container.name }}</h1>
+      <p class="muted" style="margin: 0">{{ container.profile_string }}</p>
+    </div>
+    <div
+      hx-get="/fragments/containers/{{ container.name }}/status"
+      hx-trigger="load, every 10s"
+      hx-swap="innerHTML"
+    >
+      {% include "fragments/status_badge.html" with context %}
+    </div>
+  </div>
+
+  <div class="field-grid" style="margin-top: 12px">
+    <div>
+      <strong>Created:</strong>
+      <div class="muted">{{ container.created_at }}</div>
+    </div>
+    <div>
+      <strong>Last Used:</strong>
+      <div class="muted">{{ container.last_used or "never" }}</div>
+    </div>
+  </div>
+
+  <div class="actions" style="margin-top: 14px">
+    <button
+      class="button"
+      hx-post="/fragments/containers/{{ container.name }}/start"
+      hx-target="#container-row-{{ container.name }}"
+      hx-swap="outerHTML"
+    >Start</button>
+    <button
+      class="button warn"
+      hx-post="/fragments/containers/{{ container.name }}/stop"
+      hx-target="#container-row-{{ container.name }}"
+      hx-swap="outerHTML"
+    >Stop</button>
+    <button
+      class="button bad"
+      hx-delete="/fragments/containers/{{ container.name }}"
+      hx-confirm="Delete container {{ container.name }}?"
+      hx-on::after-request="if (event.detail.successful) window.location = '/'"
+    >Delete</button>
+    <a class="button" href="/containers/{{ container.name }}/shell" target="_blank" rel="noreferrer">Open Shell</a>
+    <a class="button" href="/containers/{{ container.name }}/code" target="_blank" rel="noreferrer">Open VS Code</a>
+  </div>
+</section>
+
+<section class="panel" style="margin-top: 14px">
+  <h2 style="margin-top: 0">Snapshots</h2>
+  <form
+    class="actions"
+    hx-post="/fragments/containers/{{ container.name }}/snapshots"
+    hx-target="#snapshot-list"
+    hx-swap="innerHTML"
+  >
+    <input type="text" name="snapshot_name" placeholder="snapshot name" required />
+    <button type="submit" class="button">Create Snapshot</button>
+  </form>
+
+  <div
+    id="snapshot-list"
+    style="margin-top: 12px"
+    hx-get="/fragments/containers/{{ container.name }}/snapshots"
+    hx-trigger="load"
+    hx-swap="innerHTML"
+  >
+    {% include "fragments/snapshot_list.html" with context %}
+  </div>
+</section>
+
+<section class="panel" style="margin-top: 14px">
+  <h2 style="margin-top: 0">Container Row Preview</h2>
+  <table>
+    <tbody>
+      {% set container = container %}
+      {% include "fragments/container_row.html" %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/backend/app/templates/create.html
+++ b/backend/app/templates/create.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="panel" x-data="profileBuilder()">
+  <h1 style="margin-top: 0">Create Environment</h1>
+  <p class="muted">Compose a profile string from declarative profile categories, then launch the container.</p>
+
+  <form
+    hx-post="/fragments/containers/create"
+    hx-target="#create-result"
+    hx-swap="innerHTML"
+    style="margin-top: 14px"
+  >
+    <div class="field-grid">
+      <label>
+        Container Name
+        <input type="text" name="name" placeholder="devbox" required pattern="[a-z][a-z0-9-]*" maxlength="63" />
+      </label>
+      <label>
+        Use Case
+        <select x-model="useCase" @change="recompute()">
+          {% for item in use_cases %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <div class="field-grid" style="margin-top: 12px">
+      <label>
+        Tools
+        <select x-model="tools" multiple size="6" @change="recompute()">
+          {% for item in tools %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>
+        Agents
+        <select x-model="agents" multiple size="6" @change="recompute()">
+          {% for item in agents %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <div style="margin-top: 12px">
+      <label>
+        Services
+        <select x-model="services" multiple size="5" @change="recompute()">
+          {% for item in services %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <div class="field-grid" style="margin-top: 12px">
+      <label>
+        Profile String
+        <input type="text" name="profile_string" x-model="profileString" readonly />
+      </label>
+      <label>
+        Secrets (KEY=VALUE)
+        <textarea name="secrets_text" rows="3" placeholder="GITHUB_TOKEN=...\nHF_TOKEN=..."></textarea>
+      </label>
+    </div>
+
+    <div class="field-grid" style="margin-top: 12px">
+      <label>
+        CPU Limit
+        <input type="number" name="cpu_limit" min="1" max="64" value="2" required />
+      </label>
+      <label>
+        Memory Limit (GB)
+        <input type="number" name="memory_limit_gb" min="1" max="256" value="4" required />
+      </label>
+    </div>
+
+    <div class="actions" style="margin-top: 12px">
+      <label><input type="checkbox" name="ephemeral" /> Ephemeral container</label>
+      <label><input type="checkbox" name="enable_gpu" /> Enable GPU profile compatibility</label>
+    </div>
+
+    <div class="actions" style="margin-top: 14px">
+      <button type="submit" class="button primary">Create Container</button>
+      <a class="button" href="/">Cancel</a>
+    </div>
+  </form>
+
+  <div id="create-result" style="margin-top: 12px"></div>
+</section>
+
+<script>
+  function profileBuilder() {
+    return {
+      useCase: "{{ use_cases[0].slug if use_cases else 'dev' }}",
+      tools: [],
+      agents: [],
+      services: [],
+      profileString: "",
+      recompute() {
+        const segments = [this.useCase, ...this.tools, ...this.agents, ...this.services].filter(Boolean);
+        this.profileString = "/" + segments.join("/") + "///";
+      },
+      init() {
+        this.recompute();
+      },
+    };
+  }
+</script>
+{% endblock %}

--- a/backend/app/templates/fragments/container_list.html
+++ b/backend/app/templates/fragments/container_list.html
@@ -1,0 +1,20 @@
+{% if records %}
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Profile</th>
+      <th>Status</th>
+      <th>Last used</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for container in records %}
+      {% include "fragments/container_row.html" %}
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted" style="margin: 0">No containers yet. Create one to begin.</p>
+{% endif %}

--- a/backend/app/templates/fragments/container_row.html
+++ b/backend/app/templates/fragments/container_row.html
@@ -1,0 +1,38 @@
+<tr id="container-row-{{ container.name }}">
+  <td>
+    <a href="/containers/{{ container.name }}">{{ container.name }}</a>
+  </td>
+  <td>
+    <div>{{ container.profile_string }}</div>
+    <div class="muted">{{ container.resolved_profiles | join(", ") }}</div>
+  </td>
+  <td>
+    {% include "fragments/status_badge.html" %}
+  </td>
+  <td>{{ container.last_used or "never" }}</td>
+  <td>
+    <div class="actions">
+      <button
+        class="button"
+        hx-post="/fragments/containers/{{ container.name }}/start"
+        hx-target="#container-row-{{ container.name }}"
+        hx-swap="outerHTML"
+      >Start</button>
+      <button
+        class="button warn"
+        hx-post="/fragments/containers/{{ container.name }}/stop"
+        hx-target="#container-row-{{ container.name }}"
+        hx-swap="outerHTML"
+      >Stop</button>
+      <button
+        class="button bad"
+        hx-delete="/fragments/containers/{{ container.name }}"
+        hx-target="#container-row-{{ container.name }}"
+        hx-swap="outerHTML"
+        hx-confirm="Delete container {{ container.name }}?"
+      >Delete</button>
+      <a class="button" href="/containers/{{ container.name }}/shell" target="_blank" rel="noreferrer">Shell</a>
+      <a class="button" href="/containers/{{ container.name }}/code" target="_blank" rel="noreferrer">Code</a>
+    </div>
+  </td>
+</tr>

--- a/backend/app/templates/fragments/create_result.html
+++ b/backend/app/templates/fragments/create_result.html
@@ -1,0 +1,5 @@
+{% if success %}
+<div class="note-ok">{{ message }}</div>
+{% else %}
+<div class="note-error">{{ message }}</div>
+{% endif %}

--- a/backend/app/templates/fragments/snapshot_list.html
+++ b/backend/app/templates/fragments/snapshot_list.html
@@ -1,0 +1,26 @@
+{% if snapshots %}
+<table>
+  <thead>
+    <tr>
+      <th>Snapshot</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for snapshot in snapshots %}
+    <tr>
+      <td>{{ snapshot }}</td>
+      <td>
+        <button
+          class="button"
+          hx-post="/fragments/containers/{{ name or container.name }}/snapshots/{{ snapshot }}/restore"
+          hx-confirm="Restore snapshot {{ snapshot }}?"
+        >Restore</button>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted" style="margin: 0">No snapshots yet.</p>
+{% endif %}

--- a/backend/app/templates/fragments/status_badge.html
+++ b/backend/app/templates/fragments/status_badge.html
@@ -1,0 +1,2 @@
+{% set current_status = status if status is defined else container.status %}
+<span class="status {{ current_status }}">{{ current_status }}</span>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -1,8 +1,31 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>YETAOS MVP</h1>
-<p>Backend API is available at /api/v1.</p>
-<div class="card">
-  <p>Use the API endpoints to manage containers. Frontend interactions are intentionally lightweight in this MVP.</p>
-</div>
+<section class="panel">
+  <div class="row">
+    <div>
+      <h1 style="margin: 0 0 6px">Containers</h1>
+      <p class="muted" style="margin: 0">Live view of your dev environments. Status refreshes every 10 seconds.</p>
+    </div>
+    <a class="button primary" href="/create">Create Environment</a>
+  </div>
+</section>
+
+<section style="margin-top: 14px" class="panel">
+  <div
+    id="container-list"
+    hx-get="/fragments/containers"
+    hx-trigger="load, every 10s"
+    hx-swap="innerHTML"
+  >
+    {% include "fragments/container_list.html" %}
+  </div>
+</section>
+
+<script>
+  document.body.addEventListener("snapshot-restored", function () {
+    if (window.htmx) {
+      htmx.trigger("#container-list", "refresh");
+    }
+  });
+</script>
 {% endblock %}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "uvicorn==0.34.0",
   "pydantic==2.10.6",
   "pydantic-settings==2.8.1",
+  "python-multipart==0.0.20",
   "pylxd==2.3.5",
   "pyyaml==6.0.2",
   "python-json-logger==3.2.1",

--- a/backend/tests/test_ui.py
+++ b/backend/tests/test_ui.py
@@ -1,0 +1,80 @@
+def test_dashboard_page_renders(client) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Containers" in response.text
+
+
+def test_create_page_renders(client) -> None:
+    response = client.get("/create")
+    assert response.status_code == 200
+    assert "Create Environment" in response.text
+
+
+def test_htmx_create_redirects_to_detail(client) -> None:
+    response = client.post(
+        "/fragments/containers/create",
+        data={
+            "name": "devbox",
+            "profile_string": "/dev/python///",
+            "cpu_limit": "2",
+            "memory_limit_gb": "4",
+            "secrets_text": "TOKEN=x",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 201
+    assert response.headers["HX-Redirect"] == "/containers/devbox"
+
+
+def test_detail_page_and_actions(client) -> None:
+    create_response = client.post(
+        "/api/v1/containers",
+        json={
+            "name": "devbox",
+            "profile_string": "/dev/python///",
+            "cpu_limit": 2,
+            "memory_limit_gb": 4,
+            "secrets": {},
+        },
+    )
+    assert create_response.status_code == 201
+
+    detail = client.get("/containers/devbox")
+    assert detail.status_code == 200
+    assert "devbox" in detail.text
+
+    start = client.post("/fragments/containers/devbox/start")
+    assert start.status_code == 200
+    assert "running" in start.text
+
+    stop = client.post("/fragments/containers/devbox/stop")
+    assert stop.status_code == 200
+    assert "stopped" in stop.text
+
+
+def test_snapshot_fragment_flow(client) -> None:
+    create_response = client.post(
+        "/api/v1/containers",
+        json={
+            "name": "snapbox",
+            "profile_string": "/dev/python///",
+            "cpu_limit": 2,
+            "memory_limit_gb": 4,
+            "secrets": {},
+        },
+    )
+    assert create_response.status_code == 201
+
+    create_snapshot = client.post(
+        "/fragments/containers/snapbox/snapshots",
+        data={"snapshot_name": "baseline"},
+    )
+    assert create_snapshot.status_code == 200
+    assert "baseline" in create_snapshot.text
+
+    restore = client.post(
+        "/fragments/containers/snapbox/snapshots/baseline/restore",
+        headers={"HX-Request": "true"},
+    )
+    assert restore.status_code == 200
+    assert restore.headers["HX-Trigger"] == "snapshot-restored"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -488,6 +488,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -646,6 +655,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pylxd" },
     { name = "python-json-logger" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "uvicorn" },
 ]
@@ -668,6 +678,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.8.1" },
     { name = "pylxd", specifier = "==2.3.5" },
     { name = "python-json-logger", specifier = "==3.2.1" },
+    { name = "python-multipart", specifier = "==0.0.20" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "uvicorn", specifier = "==0.34.0" },
 ]


### PR DESCRIPTION
Implements Milestone 3 frontend UI using HTMX 2.x + Alpine.js 3.x with no build step, served via Jinja2 from FastAPI.

## What's added

**New UI router (`app/api/ui.py`)**
- Full-page routes: `GET /` dashboard, `GET /create` form, `GET /containers/{name}` detail
- HTMX fragment endpoints: container list (polled every 10s), start/stop/delete actions, status badge, snapshot list/create/restore
- Form POST handler for container creation with HTMX redirect on success

**Templates**
- `base.html` — nav bar, CSS design system (IBM Plex, no framework dependency)
- `index.html` — dashboard with auto-polling container list
- `create.html` — profile-string builder using Alpine.js (use-case + tools + agents + services dropdowns)
- `container.html` — detail page with live status badge, start/stop/delete, shell/code links, snapshot management
- Fragments: `container_list`, `container_row`, `status_badge`, `snapshot_list`, `create_result`

**Dependency**
- Added `python-multipart==0.0.20` required by FastAPI `Form` parameters

**Tests (`tests/test_ui.py`)**
- Dashboard and create page render
- HTMX create form redirects to detail on success
- Detail page renders; start/stop actions return updated row fragment
- Snapshot create and restore fragment flow
- All 12 tests pass with zero deprecation warnings

## Design notes
- All HTML mutations are HTMX fragment swaps; no full-page reloads
- Profile string is composed client-side by Alpine.js from dropdown selections
- Status polling uses `hx-trigger="every 10s"` on the container list div
- No build step; HTMX and Alpine.js loaded from CDN in `base.html`

## Checklist
- [x] `uv run pytest` — 12 passed
- [x] `uv run ruff check app tests` — all checks passed
- [x] README TODO marked complete