### PR TITLE
feat: complete Milestone 4 (container detail, ttyd/code-server services, export, proxying)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,13 @@
 	"features": {
 		"ghcr.io/devcontainers-extra/features/curl-apt-get:1": {},
 		"ghcr.io/devcontainers-extra/features/uv:1": {}
+	},
+	"forwardPorts": [8000],
+	"portsAttributes": {
+		"8000": {
+			"label": "YETAOS Backend",
+			"onAutoForward": "openPreview"
+		}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@ This repository contains a **Dev Environment Orchestrator** for a home server us
 
 The goal is to provide a **deterministic, reproducible, and privacy-respecting** way to launch curated dev environments (Python+ROCm, Clang+RISC-V, Node+Electron, Blender, ComfyUI, etc.) with AI CLIs like **Claude CLI** and **Copilot CLI**.
 
+## Plan Files
+- **docs/architecture.md**: 
+  - Project Archtecture
+  - Should stay stable, regardless of plan and task completion
+  - Should be updated if during implementation, a critical inconsistency or issue is found
+- **docs/plan.md**:
+  - Project Plan
+  - Should be updated during implementation
+  - Change future tasks if current implementation necessitates the change
+  - Always mark tasks as complete when done
+- **docs/user-guide.md**:
+  - User Guide
+  - Update as new features are implemented
+  - Change when new features or bug fixes change behavior or user experience.
+
 ## Architectural principles
 
 - Prefer **explicit, declarative configuration** over magic.

--- a/backend/app/api/containers.py
+++ b/backend/app/api/containers.py
@@ -1,7 +1,9 @@
 from datetime import UTC, datetime
+import io
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import StreamingResponse
 
 from app.api.deps import get_lxd_service, get_registry, get_store, verify_api_key
 from app.config import get_settings
@@ -229,3 +231,18 @@ async def restore_snapshot(
         raise HTTPException(status_code=404, detail="container not found")
     await lxd.restore_snapshot(name, snapshot)
     return {"status": "accepted", "snapshot": snapshot}
+
+
+@router.get("/{name}/export", dependencies=[Depends(verify_api_key)])
+async def export_container_workspace(
+    name: str,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> StreamingResponse:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    payload = await lxd.export_workspace(name)
+    filename = f"{name}-workspace.tar.gz"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    return StreamingResponse(io.BytesIO(payload), media_type="application/gzip", headers=headers)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,6 +2,7 @@ from fastapi import Depends, Header, HTTPException, Request, status
 
 from app.config import Settings, get_settings
 from app.lxd.containers import LXDContainerService
+from app.lxd.mock import get_mock_lxd_service
 from app.profiles.registry import ProfileRegistry
 from app.store.json_store import JsonStore
 
@@ -15,6 +16,8 @@ def get_registry(settings: Settings = Depends(get_settings)) -> ProfileRegistry:
 
 
 def get_lxd_service(settings: Settings = Depends(get_settings)) -> LXDContainerService:
+    if settings.mock_lxd:
+        return get_mock_lxd_service()
     return LXDContainerService(socket_path=settings.lxd_socket)
 
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -10,13 +10,14 @@ router = APIRouter(tags=["health"])
 @router.get("/health")
 async def health() -> dict[str, str]:
     settings = get_settings()
-    lxd_status = "ok"
+    lxd_status = "mock" if settings.mock_lxd else "ok"
     db_status = "ok"
 
-    try:
-        check_lxd_socket(settings.lxd_socket)
-    except Exception as exc:  # noqa: BLE001
-        lxd_status = f"error: {exc}"
+    if not settings.mock_lxd:
+        try:
+            check_lxd_socket(settings.lxd_socket)
+        except Exception as exc:  # noqa: BLE001
+            lxd_status = f"error: {exc}"
 
     try:
         JsonStore(settings.store_path).load()

--- a/backend/app/api/ui.py
+++ b/backend/app/api/ui.py
@@ -1,0 +1,337 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import ValidationError
+
+from app.api.containers import _write_secrets
+from app.api.deps import get_lxd_service, get_registry, get_store
+from app.config import get_settings
+from app.lxd.container_init import build_user_data
+from app.lxd.containers import LXDContainerService
+from app.profiles.registry import ProfileRegistry
+from app.profiles.resolver import ProfileResolver
+from app.schemas import CreateContainerRequest
+from app.store.json_store import JsonStore
+from app.store.models import ContainerRecord
+
+router = APIRouter(tags=["ui"])
+templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+
+def _form_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.lower() in {"1", "true", "on", "yes"}
+
+
+def _parse_secrets(raw: str) -> dict[str, str]:
+    secrets: dict[str, str] = {}
+    for line in raw.splitlines():
+        entry = line.strip()
+        if not entry or "=" not in entry:
+            continue
+        key, value = entry.split("=", maxsplit=1)
+        key = key.strip()
+        if key:
+            secrets[key] = value.strip()
+    return secrets
+
+
+def _profile_options(registry: ProfileRegistry, category: str) -> list[dict[str, str]]:
+    profiles = registry.load_all().values()
+    scoped = [profile for profile in profiles if profile.category == category]
+    return [
+        {
+            "value": profile.name,
+            "slug": profile.name.split("/", maxsplit=1)[1],
+            "label": profile.name,
+        }
+        for profile in sorted(scoped, key=lambda item: item.name)
+    ]
+
+
+async def _with_status(record: ContainerRecord, lxd: LXDContainerService, store: JsonStore) -> ContainerRecord:
+    try:
+        record.status = await lxd.get_status(record.name)
+        store.upsert(record)
+    except Exception:  # noqa: BLE001
+        record.status = "error"
+    return record
+
+
+async def _all_records(store: JsonStore, lxd: LXDContainerService) -> list[ContainerRecord]:
+    records = list(store.load().values())
+    records.sort(key=lambda item: item.name)
+    results: list[ContainerRecord] = []
+    for record in records:
+        results.append(await _with_status(record, lxd, store))
+    return results
+
+
+@router.get("/", response_class=HTMLResponse)
+async def dashboard(
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    records = await _all_records(store, lxd)
+    return templates.TemplateResponse(request, "index.html", {"records": records})
+
+
+@router.get("/create", response_class=HTMLResponse)
+async def create_page(
+    request: Request,
+    registry: ProfileRegistry = Depends(get_registry),
+) -> HTMLResponse:
+    use_cases = _profile_options(registry, "use-case")
+    tools = _profile_options(registry, "tool")
+    agents = _profile_options(registry, "agent")
+    services = _profile_options(registry, "service")
+
+    return templates.TemplateResponse(
+        request,
+        "create.html",
+        {
+            "use_cases": use_cases,
+            "tools": tools,
+            "agents": agents,
+            "services": services,
+        },
+    )
+
+
+@router.get("/containers/{name}", response_class=HTMLResponse)
+async def container_detail_page(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    snapshots = await lxd.list_snapshots(name)
+    record = await _with_status(record, lxd, store)
+
+    return templates.TemplateResponse(request, "container.html", {"container": record, "snapshots": snapshots})
+
+
+@router.get("/fragments/containers", response_class=HTMLResponse)
+async def containers_fragment(
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    records = await _all_records(store, lxd)
+    return templates.TemplateResponse(request, "fragments/container_list.html", {"records": records})
+
+
+@router.post("/fragments/containers/create")
+async def create_container_from_form(
+    request: Request,
+    name: str = Form(...),
+    profile_string: str = Form(...),
+    ephemeral: str | None = Form(default=None),
+    cpu_limit: int = Form(default=2),
+    memory_limit_gb: int = Form(default=4),
+    enable_gpu: str | None = Form(default=None),
+    secrets_text: str = Form(default=""),
+    store: JsonStore = Depends(get_store),
+    registry: ProfileRegistry = Depends(get_registry),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    if store.get(name):
+        return templates.TemplateResponse(
+            request,
+            "fragments/create_result.html",
+            {"success": False, "message": "Container already exists."},
+            status_code=status.HTTP_409_CONFLICT,
+        )
+
+    secrets = _parse_secrets(secrets_text)
+    try:
+        body = CreateContainerRequest(
+            name=name,
+            profile_string=profile_string,
+            ephemeral=_form_bool(ephemeral),
+            cpu_limit=cpu_limit,
+            memory_limit_gb=memory_limit_gb,
+            enable_gpu=_form_bool(enable_gpu),
+            secrets=secrets,
+        )
+    except ValidationError as exc:
+        message = "; ".join(err["msg"] for err in exc.errors())
+        return templates.TemplateResponse(
+            request,
+            "fragments/create_result.html",
+            {"success": False, "message": message},
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+
+    resolver = ProfileResolver(registry.load_all())
+    try:
+        resolved_profiles = resolver.resolve_from_string(body.profile_string)
+    except ValueError as exc:
+        return templates.TemplateResponse(
+            request,
+            "fragments/create_result.html",
+            {"success": False, "message": str(exc)},
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+
+    user_data = build_user_data(body.profile_string, resolved_profiles, registry)
+    settings = get_settings()
+    workspace_path = settings.workspaces_dir / body.name
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    _write_secrets(body.name, body.secrets, settings.secrets_dir)
+
+    lxd_config = {
+        "limits.cpu": str(body.cpu_limit),
+        "limits.memory": f"{body.memory_limit_gb}GB",
+    }
+
+    await lxd.create_container(body.name, resolved_profiles, user_data, lxd_config)
+
+    record = ContainerRecord(
+        name=body.name,
+        profile_string=body.profile_string,
+        resolved_profiles=resolved_profiles,
+        ephemeral=body.ephemeral,
+        gpu_enabled=body.enable_gpu,
+        created_at=datetime.now(UTC),
+        last_used=None,
+        status="starting",
+        workspace_path=str(workspace_path),
+    )
+    store.upsert(record)
+
+    if request.headers.get("HX-Request") == "true":
+        return HTMLResponse(
+            "",
+            status_code=status.HTTP_201_CREATED,
+            headers={"HX-Redirect": f"/containers/{body.name}"},
+        )
+    return RedirectResponse(url=f"/containers/{body.name}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/fragments/containers/{name}/start", response_class=HTMLResponse)
+async def start_container_from_ui(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.start_container(name)
+    record.status = "running"
+    record.last_used = datetime.now(UTC)
+    store.upsert(record)
+
+    return templates.TemplateResponse(request, "fragments/container_row.html", {"container": record})
+
+
+@router.post("/fragments/containers/{name}/stop", response_class=HTMLResponse)
+async def stop_container_from_ui(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.stop_container(name)
+    record.status = "stopped"
+    store.upsert(record)
+
+    if record.ephemeral:
+        await lxd.delete_container(name)
+        store.delete(name)
+        return HTMLResponse("")
+
+    return templates.TemplateResponse(request, "fragments/container_row.html", {"container": record})
+
+
+@router.delete("/fragments/containers/{name}")
+async def delete_container_from_ui(
+    name: str,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.delete_container(name)
+    store.delete(name)
+    return HTMLResponse("")
+
+
+@router.get("/fragments/containers/{name}/status", response_class=HTMLResponse)
+async def container_status_fragment(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    record = store.get(name)
+    if not record:
+        raise HTTPException(status_code=404, detail="container not found")
+
+    record = await _with_status(record, lxd, store)
+    return templates.TemplateResponse(request, "fragments/status_badge.html", {"status": record.status})
+
+
+@router.get("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
+async def snapshots_fragment(
+    name: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    snapshots = await lxd.list_snapshots(name)
+    return templates.TemplateResponse(request, "fragments/snapshot_list.html", {"name": name, "snapshots": snapshots})
+
+
+@router.post("/fragments/containers/{name}/snapshots", response_class=HTMLResponse)
+async def create_snapshot_from_ui(
+    name: str,
+    request: Request,
+    snapshot_name: str = Form(...),
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> HTMLResponse:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.create_snapshot(name, snapshot_name)
+    snapshots = await lxd.list_snapshots(name)
+    return templates.TemplateResponse(request, "fragments/snapshot_list.html", {"name": name, "snapshots": snapshots})
+
+
+@router.post("/fragments/containers/{name}/snapshots/{snapshot}/restore")
+async def restore_snapshot_from_ui(
+    name: str,
+    snapshot: str,
+    request: Request,
+    store: JsonStore = Depends(get_store),
+    lxd: LXDContainerService = Depends(get_lxd_service),
+) -> Response:
+    if not store.get(name):
+        raise HTTPException(status_code=404, detail="container not found")
+
+    await lxd.restore_snapshot(name, snapshot)
+    if request.headers.get("HX-Request") == "true":
+        return HTMLResponse("", headers={"HX-Trigger": "snapshot-restored"})
+    return RedirectResponse(url=f"/containers/{name}", status_code=status.HTTP_303_SEE_OTHER)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     workspaces_dir: Path = Field(default=Path("/tmp/yetaos/workspaces"), alias="YETAOS_WORKSPACES_DIR")
     secrets_dir: Path = Field(default=Path("/tmp/yetaos/secrets"), alias="YETAOS_SECRETS_DIR")
     models_dir: Path = Field(default=Path("/tmp/yetaos/models"), alias="YETAOS_MODELS_DIR")
+    mock_lxd: bool = Field(default=False, alias="YETAOS_MOCK_LXD")
     api_key: str | None = Field(default=None, alias="YETAOS_API_KEY")
     host: str = Field(default="0.0.0.0", alias="YETAOS_HOST")
     port: int = Field(default=8000, alias="YETAOS_PORT")

--- a/backend/app/lxd/client.py
+++ b/backend/app/lxd/client.py
@@ -10,4 +10,4 @@ def check_lxd_socket(socket_path: str) -> None:
 def get_pylxd_client(socket_path: str) -> Any:
     from pylxd import Client
 
-    return Client(endpoint=f"unix://{socket_path}")
+    return Client(endpoint=socket_path)

--- a/backend/app/lxd/containers.py
+++ b/backend/app/lxd/containers.py
@@ -60,3 +60,13 @@ class LXDContainerService:
         container = await self._run(self._client.containers.get, name)
         snapshot = await self._run(container.snapshots.get, snapshot_name)
         await self._run(snapshot.restore, wait=True)
+
+    async def export_workspace(self, name: str) -> bytes:
+        container = await self._run(self._client.containers.get, name)
+        archive_path = "/tmp/yetaos-export.tar.gz"
+        await self._run(container.execute, ["sh", "-lc", f"tar czf {archive_path} -C /workspace ."])
+        payload = await self._run(container.files.get, archive_path)
+        await self._run(container.execute, ["rm", "-f", archive_path])
+        if isinstance(payload, bytes):
+            return payload
+        return str(payload).encode("utf-8")

--- a/backend/app/lxd/containers.py
+++ b/backend/app/lxd/containers.py
@@ -8,8 +8,14 @@ from app.lxd.client import get_pylxd_client
 
 class LXDContainerService:
     def __init__(self, socket_path: str, client_factory: Callable[[str], Any] | None = None) -> None:
-        factory = client_factory or get_pylxd_client
-        self._client = factory(socket_path)
+        self._socket_path = socket_path
+        self._client_factory = client_factory or get_pylxd_client
+        self._client: Any | None = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            self._client = self._client_factory(self._socket_path)
+        return self._client
 
     async def _run(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
@@ -28,41 +34,50 @@ class LXDContainerService:
             "profiles": [],
             "config": {**config, "user.user-data": user_data},
         }
-        container = await self._run(self._client.containers.create, definition, wait=True)
+        client = self._get_client()
+        container = await self._run(client.containers.create, definition, wait=True)
         await self._run(container.start, wait=True)
 
     async def start_container(self, name: str) -> None:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         await self._run(container.start, wait=True)
 
     async def stop_container(self, name: str) -> None:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         await self._run(container.stop, wait=True)
 
     async def delete_container(self, name: str) -> None:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         await self._run(container.delete, wait=True)
 
     async def get_status(self, name: str) -> str:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         return str(container.status).lower()
 
     async def create_snapshot(self, name: str, snapshot_name: str) -> None:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         await self._run(container.snapshots.create, snapshot_name, stateful=False, wait=True)
 
     async def list_snapshots(self, name: str) -> list[str]:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         snapshots = await self._run(lambda: list(container.snapshots.all()))
         return [snap.name for snap in snapshots]
 
     async def restore_snapshot(self, name: str, snapshot_name: str) -> None:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         snapshot = await self._run(container.snapshots.get, snapshot_name)
         await self._run(snapshot.restore, wait=True)
 
     async def export_workspace(self, name: str) -> bytes:
-        container = await self._run(self._client.containers.get, name)
+        client = self._get_client()
+        container = await self._run(client.containers.get, name)
         archive_path = "/tmp/yetaos-export.tar.gz"
         await self._run(container.execute, ["sh", "-lc", f"tar czf {archive_path} -C /workspace ."])
         payload = await self._run(container.files.get, archive_path)

--- a/backend/app/lxd/mock.py
+++ b/backend/app/lxd/mock.py
@@ -1,0 +1,88 @@
+from functools import lru_cache
+from typing import Any
+
+from app.lxd.containers import LXDContainerService
+
+
+class MockSnapshot:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def restore(self, wait: bool = True) -> None:
+        _ = wait
+
+
+class MockSnapshots:
+    def __init__(self) -> None:
+        self._snapshots: dict[str, MockSnapshot] = {}
+
+    def create(self, name: str, stateful: bool = False, wait: bool = True) -> None:
+        _ = (stateful, wait)
+        self._snapshots[name] = MockSnapshot(name)
+
+    def all(self) -> list[MockSnapshot]:
+        return list(self._snapshots.values())
+
+    def get(self, name: str) -> MockSnapshot:
+        return self._snapshots[name]
+
+
+class MockFiles:
+    def get(self, path: str) -> bytes:
+        _ = path
+        return b"mock-workspace-archive"
+
+
+class MockContainer:
+    def __init__(self, name: str, config: dict[str, str], collection: "MockContainersCollection") -> None:
+        self.name = name
+        self.config = config
+        self.status = "stopped"
+        self.snapshots = MockSnapshots()
+        self.files = MockFiles()
+        self._collection = collection
+
+    def start(self, wait: bool = True) -> None:
+        _ = wait
+        self.status = "running"
+
+    def stop(self, wait: bool = True) -> None:
+        _ = wait
+        self.status = "stopped"
+
+    def delete(self, wait: bool = True) -> None:
+        _ = wait
+        self._collection.remove(self.name)
+
+    def execute(self, cmd: list[str], environment: dict[str, str] | None = None) -> tuple[int, str, str]:
+        _ = (cmd, environment)
+        return (0, "", "")
+
+
+class MockContainersCollection:
+    def __init__(self) -> None:
+        self._containers: dict[str, MockContainer] = {}
+
+    def create(self, definition: dict[str, Any], wait: bool = True) -> MockContainer:
+        _ = wait
+        name = str(definition["name"])
+        container = MockContainer(name=name, config=definition.get("config", {}), collection=self)
+        self._containers[name] = container
+        return container
+
+    def get(self, name: str) -> MockContainer:
+        return self._containers[name]
+
+    def remove(self, name: str) -> None:
+        self._containers.pop(name, None)
+
+
+class MockLXDClient:
+    def __init__(self) -> None:
+        self.containers = MockContainersCollection()
+
+
+@lru_cache(maxsize=1)
+def get_mock_lxd_service() -> LXDContainerService:
+    client = MockLXDClient()
+    return LXDContainerService(socket_path="/tmp/mock-lxd.sock", client_factory=lambda _: client)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,13 @@ from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 
 from app.api.containers import router as containers_router
 from app.api.health import router as health_router
 from app.api.profiles import router as profiles_router
+from app.api.ui import router as ui_router
 from app.config import get_settings
 
 
@@ -27,11 +26,6 @@ app = FastAPI(title="YETAOS", version="0.1.0", lifespan=lifespan)
 app.include_router(health_router)
 app.include_router(profiles_router)
 app.include_router(containers_router)
+app.include_router(ui_router)
 
-templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
-
-
-@app.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse("index.html", {"request": request})

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -4,11 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>YETAOS</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <style>
       :root { color-scheme: light; }
       body { font-family: "IBM Plex Sans", sans-serif; margin: 0; background: linear-gradient(140deg, #eef7ff, #f8fff0); }
       main { max-width: 980px; margin: 0 auto; padding: 24px; }
       .card { background: #fff; border: 1px solid #d7e4ef; border-radius: 12px; padding: 16px; }
+      input, select, textarea, button { font: inherit; padding: 8px; }
+      button { cursor: pointer; }
     </style>
   </head>
   <body>

--- a/backend/app/templates/container.html
+++ b/backend/app/templates/container.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="card">
+  <h1 style="margin-top: 0">{{ container.name }}</h1>
+  <p style="margin-top: 0; color: #426077">{{ container.profile_string }}</p>
+
+  <div
+    id="status-fragment"
+    hx-get="/fragments/containers/{{ container.name }}/status"
+    hx-trigger="load, every 10s, refresh"
+    hx-swap="innerHTML"
+  >
+    {% include "fragments/status_badge.html" with context %}
+  </div>
+
+  <div style="display: flex; gap: 18px; flex-wrap: wrap; margin: 12px 0;">
+    <div><strong>Created:</strong> {{ container.created_at }}</div>
+    <div><strong>Last used:</strong> {{ container.last_used or "never" }}</div>
+  </div>
+
+  <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+    <button
+      hx-post="/fragments/containers/{{ container.name }}/start"
+      hx-swap="none"
+      hx-on::after-request="if (event.detail.successful) htmx.trigger('#status-fragment', 'refresh')"
+    >Start</button>
+    <button
+      hx-post="/fragments/containers/{{ container.name }}/stop"
+      hx-swap="none"
+      hx-on::after-request="if (event.detail.successful) htmx.trigger('#status-fragment', 'refresh')"
+    >Stop</button>
+    <button
+      hx-delete="/fragments/containers/{{ container.name }}"
+      hx-confirm="Delete container {{ container.name }}?"
+      hx-on::after-request="if (event.detail.successful) window.location = '/'"
+    >Delete</button>
+    <a href="/containers/{{ container.name }}/shell" target="_blank" rel="noreferrer">Open Shell</a>
+    <a href="/containers/{{ container.name }}/code" target="_blank" rel="noreferrer">Open VS Code</a>
+    <a href="/api/v1/containers/{{ container.name }}/export">Export Workspace</a>
+  </div>
+</section>
+
+<section class="card" style="margin-top: 12px;">
+  <h2 style="margin-top: 0">Snapshots</h2>
+  <form
+    hx-post="/fragments/containers/{{ container.name }}/snapshots"
+    hx-target="#snapshot-list"
+    hx-swap="innerHTML"
+  >
+    <input type="text" name="snapshot_name" placeholder="snapshot name" required />
+    <button type="submit">Create Snapshot</button>
+  </form>
+
+  <div
+    id="snapshot-list"
+    style="margin-top: 12px"
+    hx-get="/fragments/containers/{{ container.name }}/snapshots"
+    hx-trigger="load"
+    hx-swap="innerHTML"
+  >
+    {% include "fragments/snapshot_list.html" with context %}
+  </div>
+</section>
+{% endblock %}

--- a/backend/app/templates/create.html
+++ b/backend/app/templates/create.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="card">
+  <h1 style="margin-top: 0">Create Environment</h1>
+  <p style="margin-top: 0; color: #426077">Compose a profile string and launch a container.</p>
+
+  <form
+    hx-post="/fragments/containers/create"
+    hx-target="#create-result"
+    hx-swap="innerHTML"
+  >
+    <div style="display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));">
+      <label>
+        Name
+        <input name="name" required pattern="[a-z][a-z0-9-]*" maxlength="63" placeholder="devbox" />
+      </label>
+      <label>
+        CPU
+        <input name="cpu_limit" type="number" min="1" max="64" value="2" />
+      </label>
+      <label>
+        Memory (GB)
+        <input name="memory_limit_gb" type="number" min="1" max="256" value="4" />
+      </label>
+      <label>
+        Use-case
+        <select id="use-case-select">
+          <option value="">none</option>
+          {% for item in use_cases %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <div style="display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); margin-top: 12px;">
+      <label>
+        Tools (Ctrl/Cmd+click for multi-select)
+        <select id="tools-select" multiple size="6">
+          {% for item in tools %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+
+      <label>
+        Agents (Ctrl/Cmd+click for multi-select)
+        <select id="agents-select" multiple size="6">
+          {% for item in agents %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+
+      <label>
+        Services (Ctrl/Cmd+click for multi-select)
+        <select id="services-select" multiple size="6">
+          {% for item in services %}
+          <option value="{{ item.slug }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <input id="profile-string" type="hidden" name="profile_string" value="////" />
+
+    <label style="display: block; margin-top: 12px;">
+      Profile string
+      <input id="profile-preview" value="////" readonly />
+    </label>
+
+    <label style="display: block; margin-top: 12px;">
+      Secrets (KEY=VALUE, one per line)
+      <textarea name="secrets_text" rows="5" placeholder="GITHUB_TOKEN=...&#10;ANTHROPIC_API_KEY=..."></textarea>
+    </label>
+
+    <div style="display: flex; gap: 16px; margin-top: 12px;">
+      <label><input type="checkbox" name="ephemeral" /> Ephemeral</label>
+      <label><input type="checkbox" name="enable_gpu" /> GPU enabled</label>
+    </div>
+
+    <div style="margin-top: 14px; display: flex; gap: 10px;">
+      <button type="submit">Create</button>
+      <a href="/">Cancel</a>
+    </div>
+  </form>
+
+  <div id="create-result" style="margin-top: 12px"></div>
+</section>
+
+<script>
+  (function () {
+    const useCase = document.getElementById("use-case-select");
+    const tools = document.getElementById("tools-select");
+    const agents = document.getElementById("agents-select");
+    const services = document.getElementById("services-select");
+    const hidden = document.getElementById("profile-string");
+    const preview = document.getElementById("profile-preview");
+
+    function selectedValues(el) {
+      return Array.from(el.selectedOptions).map((opt) => opt.value).filter(Boolean).join("+");
+    }
+
+    function update() {
+      const composed = `/${useCase.value}/${selectedValues(tools)}/${selectedValues(agents)}/${selectedValues(services)}/`;
+      hidden.value = composed;
+      preview.value = composed;
+    }
+
+    [useCase, tools, agents, services].forEach((el) => {
+      el.addEventListener("change", update);
+    });
+    update();
+  })();
+</script>
+{% endblock %}

--- a/backend/app/templates/fragments/container_list.html
+++ b/backend/app/templates/fragments/container_list.html
@@ -1,0 +1,20 @@
+{% if records %}
+<table style="width: 100%; border-collapse: collapse;">
+  <thead>
+    <tr>
+      <th style="text-align: left;">Name</th>
+      <th style="text-align: left;">Profile</th>
+      <th style="text-align: left;">Status</th>
+      <th style="text-align: left;">Last Used</th>
+      <th style="text-align: left;">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for container in records %}
+      {% include "fragments/container_row.html" %}
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No containers yet. <a href="/create">Create one</a>.</p>
+{% endif %}

--- a/backend/app/templates/fragments/container_row.html
+++ b/backend/app/templates/fragments/container_row.html
@@ -1,0 +1,27 @@
+<tr id="container-row-{{ container.name }}">
+  <td><a href="/containers/{{ container.name }}">{{ container.name }}</a></td>
+  <td>{{ container.profile_string }}</td>
+  <td>{% set status = container.status %}{% include "fragments/status_badge.html" %}</td>
+  <td>{{ container.last_used or "never" }}</td>
+  <td style="display: flex; gap: 6px; flex-wrap: wrap;">
+    <button
+      hx-post="/fragments/containers/{{ container.name }}/start"
+      hx-target="#container-row-{{ container.name }}"
+      hx-swap="outerHTML"
+    >Start</button>
+    <button
+      hx-post="/fragments/containers/{{ container.name }}/stop"
+      hx-target="#container-row-{{ container.name }}"
+      hx-swap="outerHTML"
+    >Stop</button>
+    <button
+      hx-delete="/fragments/containers/{{ container.name }}"
+      hx-target="#container-row-{{ container.name }}"
+      hx-swap="outerHTML"
+      hx-confirm="Delete container {{ container.name }}?"
+    >Delete</button>
+    <a href="/containers/{{ container.name }}/shell" target="_blank" rel="noreferrer">Shell</a>
+    <a href="/containers/{{ container.name }}/code" target="_blank" rel="noreferrer">VS Code</a>
+    <a href="/api/v1/containers/{{ container.name }}/export">Export</a>
+  </td>
+</tr>

--- a/backend/app/templates/fragments/create_result.html
+++ b/backend/app/templates/fragments/create_result.html
@@ -1,0 +1,5 @@
+{% if success %}
+<p style="color: #0f5132; margin: 0;">{{ message }}</p>
+{% else %}
+<p style="color: #8a1c13; margin: 0;">{{ message }}</p>
+{% endif %}

--- a/backend/app/templates/fragments/snapshot_list.html
+++ b/backend/app/templates/fragments/snapshot_list.html
@@ -1,0 +1,16 @@
+{% set target_name = name if name is defined else container.name %}
+{% if snapshots %}
+<ul style="padding-left: 18px; margin: 0;">
+  {% for snapshot in snapshots %}
+  <li style="margin: 6px 0; display: flex; gap: 8px; align-items: center;">
+    <span>{{ snapshot }}</span>
+    <button
+      hx-post="/fragments/containers/{{ target_name }}/snapshots/{{ snapshot }}/restore"
+      hx-on::after-request="if (event.detail.successful) htmx.trigger('#status-fragment', 'refresh')"
+    >Restore</button>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p style="margin: 0;">No snapshots yet.</p>
+{% endif %}

--- a/backend/app/templates/fragments/status_badge.html
+++ b/backend/app/templates/fragments/status_badge.html
@@ -1,0 +1,10 @@
+{% set current = status if status is defined else container.status %}
+{% if current == "running" %}
+<span style="display: inline-block; padding: 2px 10px; border-radius: 999px; background: #d8f3dc; color: #1b4332; font-weight: 600;">running</span>
+{% elif current == "stopped" %}
+<span style="display: inline-block; padding: 2px 10px; border-radius: 999px; background: #e9ecef; color: #495057; font-weight: 600;">stopped</span>
+{% elif current == "starting" %}
+<span style="display: inline-block; padding: 2px 10px; border-radius: 999px; background: #fff3bf; color: #7f4f24; font-weight: 600;">starting</span>
+{% else %}
+<span style="display: inline-block; padding: 2px 10px; border-radius: 999px; background: #ffe3e3; color: #9d0208; font-weight: 600;">{{ current }}</span>
+{% endif %}

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -1,8 +1,23 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>YETAOS MVP</h1>
-<p>Backend API is available at /api/v1.</p>
-<div class="card">
-  <p>Use the API endpoints to manage containers. Frontend interactions are intentionally lightweight in this MVP.</p>
-</div>
+<section class="card">
+  <div style="display: flex; justify-content: space-between; gap: 10px; align-items: flex-start; flex-wrap: wrap;">
+    <div>
+      <h1 style="margin: 0 0 6px">Containers</h1>
+      <p style="margin: 0; color: #426077">Status refreshes every 10 seconds.</p>
+    </div>
+    <a href="/create">Create Environment</a>
+  </div>
+</section>
+
+<section class="card" style="margin-top: 12px;">
+  <div
+    id="container-list"
+    hx-get="/fragments/containers"
+    hx-trigger="load, every 10s"
+    hx-swap="innerHTML"
+  >
+    {% include "fragments/container_list.html" %}
+  </div>
+</section>
 {% endblock %}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,11 +35,17 @@ class FakeSnapshots:
 
 
 class FakeContainer:
+    class _FakeFiles:
+        def get(self, path: str) -> bytes:
+            _ = path
+            return b"fake-archive"
+
     def __init__(self, name: str, config: dict[str, str]) -> None:
         self.name = name
         self.config = config
         self.status = "stopped"
         self.snapshots = FakeSnapshots()
+        self.files = FakeContainer._FakeFiles()
 
     def start(self, wait: bool = True) -> None:
         _ = wait
@@ -51,6 +57,10 @@ class FakeContainer:
 
     def delete(self, wait: bool = True) -> None:
         _ = wait
+
+    def execute(self, cmd: list[str], environment: dict[str, str] | None = None) -> tuple[int, str, str]:
+        _ = (cmd, environment)
+        return (0, "", "")
 
 
 class FakeContainersCollection:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -42,3 +42,30 @@ def test_resolve_profiles_route(client) -> None:
     resolved = response.json()["resolved_profiles"]
     assert "service/base" in resolved
     assert "tool/python" in resolved
+
+
+def test_export_workspace(client) -> None:
+    create_response = client.post(
+        "/api/v1/containers",
+        json={
+            "name": "devbox",
+            "profile_string": "/dev/python///",
+            "ephemeral": False,
+            "cpu_limit": 2,
+            "memory_limit_gb": 4,
+            "enable_gpu": False,
+            "secrets": {},
+        },
+    )
+    assert create_response.status_code == 201
+
+    export_response = client.get("/api/v1/containers/devbox/export")
+    assert export_response.status_code == 200
+    assert export_response.headers["content-type"] == "application/gzip"
+    assert "devbox-workspace.tar.gz" in export_response.headers["content-disposition"]
+    assert export_response.content == b"fake-archive"
+
+
+def test_export_workspace_not_found(client) -> None:
+    response = client.get("/api/v1/containers/missing/export")
+    assert response.status_code == 404

--- a/backend/tests/test_lxd_client.py
+++ b/backend/tests/test_lxd_client.py
@@ -1,0 +1,30 @@
+from app.lxd.client import get_pylxd_client
+from app.lxd.containers import LXDContainerService
+
+
+def test_get_pylxd_client_passes_raw_socket_path(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class FakeClient:
+        def __init__(self, endpoint: str) -> None:
+            captured["endpoint"] = endpoint
+
+    monkeypatch.setattr("pylxd.Client", FakeClient)
+
+    get_pylxd_client("/var/snap/lxd/common/lxd/unix.socket")
+
+    assert captured["endpoint"] == "/var/snap/lxd/common/lxd/unix.socket"
+
+
+def test_lxd_service_is_lazy_until_first_operation() -> None:
+    calls: list[str] = []
+
+    def fake_factory(socket_path: str) -> object:
+        calls.append(socket_path)
+        return object()
+
+    service = LXDContainerService("/tmp/missing.sock", client_factory=fake_factory)
+
+    assert calls == []
+    service._get_client()
+    assert calls == ["/tmp/missing.sock"]

--- a/backend/tests/test_lxd_client.py
+++ b/backend/tests/test_lxd_client.py
@@ -1,5 +1,6 @@
 from app.lxd.client import get_pylxd_client
 from app.lxd.containers import LXDContainerService
+from app.lxd.mock import get_mock_lxd_service
 
 
 def test_get_pylxd_client_passes_raw_socket_path(monkeypatch) -> None:
@@ -28,3 +29,10 @@ def test_lxd_service_is_lazy_until_first_operation() -> None:
     assert calls == []
     service._get_client()
     assert calls == ["/tmp/missing.sock"]
+
+
+def test_mock_lxd_service_is_cached() -> None:
+    first = get_mock_lxd_service()
+    second = get_mock_lxd_service()
+
+    assert first is second

--- a/backend/tests/test_mock_mode.py
+++ b/backend/tests/test_mock_mode.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.main import app
+
+
+def test_health_reports_mock_mode() -> None:
+    settings = get_settings()
+    original = settings.mock_lxd
+    settings.mock_lxd = True
+    try:
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json()["lxd"] == "mock"
+    finally:
+        settings.mock_lxd = original

--- a/backend/tests/test_ui.py
+++ b/backend/tests/test_ui.py
@@ -1,0 +1,30 @@
+def test_dashboard_page_renders(client) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Containers" in response.text
+
+
+def test_create_page_renders(client) -> None:
+    response = client.get("/create")
+    assert response.status_code == 200
+    assert "Create Environment" in response.text
+
+
+def test_container_detail_shows_shell_code_and_export(client) -> None:
+    create_response = client.post(
+        "/api/v1/containers",
+        json={
+            "name": "devbox",
+            "profile_string": "/dev/python///",
+            "cpu_limit": 2,
+            "memory_limit_gb": 4,
+            "secrets": {},
+        },
+    )
+    assert create_response.status_code == 201
+
+    detail = client.get("/containers/devbox")
+    assert detail.status_code == 200
+    assert "Open Shell" in detail.text
+    assert "Open VS Code" in detail.text
+    assert "/api/v1/containers/devbox/export" in detail.text

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,6 +1,20 @@
 dev-orchestrator.local {
     tls internal
 
+    # Proxy browser shell to ttyd running inside the target container.
+    @shell path_regexp shell ^/containers/([^/]+)/shell/?(.*)$
+    handle @shell {
+        rewrite * /{re.shell.2}
+        reverse_proxy {re.shell.1}.lxd:7681
+    }
+
+    # Proxy browser IDE to code-server running inside the target container.
+    @code path_regexp code ^/containers/([^/]+)/code/?(.*)$
+    handle @code {
+        rewrite * /{re.code.2}
+        reverse_proxy {re.code.1}.lxd:8080
+    }
+
     reverse_proxy /api/* localhost:8000
     reverse_proxy /health localhost:8000
     handle /* {

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -847,7 +847,7 @@ Committed to repo; applied via `lxd init --preseed < scripts/lxd-init-preseed.ya
 - [ ] `app/templates/container.html` — full detail page
 - [ ] `lxc/profiles/service/ttyd.yaml` + init script fragment
 - [ ] `lxc/profiles/service/vscode-server.yaml` + init script fragment
-- [ ] Caddy config for shell and code-server proxying
+- [x] Caddy config for shell and code-server proxying
 - [ ] Export endpoint + frontend download button
 - [x] Snapshot create/list/restore API
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -838,17 +838,17 @@ Committed to repo; applied via `lxd init --preseed < scripts/lxd-init-preseed.ya
 
 ### Milestone 3 — Frontend MVP
 - [x] `app/templates/base.html`, `index.html` — dashboard placeholder (MVP stub)
-- [ ] `app/templates/create.html` — create form with live profile-string preview
-- [ ] HTMX polling for container status refresh
+- [x] `app/templates/create.html` — create form with live profile-string preview
+- [x] HTMX polling for container status refresh
 - [ ] SSE log stream endpoint + frontend log panel
 - [x] `app/api/profiles.py` — profiles list endpoint (populates create form dropdowns)
 
 ### Milestone 4 — Container detail + shell + VS Code
-- [ ] `app/templates/container.html` — full detail page
-- [ ] `lxc/profiles/service/ttyd.yaml` + init script fragment
-- [ ] `lxc/profiles/service/vscode-server.yaml` + init script fragment
+- [x] `app/templates/container.html` — full detail page
+- [x] `lxc/profiles/service/ttyd.yaml` + init script fragment
+- [x] `lxc/profiles/service/vscode-server.yaml` + init script fragment
 - [x] Caddy config for shell and code-server proxying
-- [ ] Export endpoint + frontend download button
+- [x] Export endpoint + frontend download button
 - [x] Snapshot create/list/restore API
 
 ### Milestone 5 — All environment templates + secrets

--- a/lxc/cloud-init/service/ttyd.sh
+++ b/lxc/cloud-init/service/ttyd.sh
@@ -1,26 +1,7 @@
 # pinned: ttyd 1.7.7 from GitHub release
 set -e
 TTYD_VERSION=1.7.7
-
-if [[ ! -x /usr/local/bin/ttyd ]]; then
-  curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" -o /usr/local/bin/ttyd
-  chmod +x /usr/local/bin/ttyd
-fi
-
-cat >/etc/systemd/system/ttyd.service <<'UNIT'
-[Unit]
-Description=ttyd terminal over web
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/ttyd -W -p 7681 /bin/bash -l
-Restart=always
-RestartSec=2
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
+test -x /usr/local/bin/ttyd || (curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" -o /usr/local/bin/ttyd && chmod +x /usr/local/bin/ttyd)
+printf '%s\n' '[Unit]' 'Description=ttyd terminal over web' 'After=network.target' '' '[Service]' 'Type=simple' 'ExecStart=/usr/local/bin/ttyd -W -p 7681 /bin/bash -l' 'Restart=always' 'RestartSec=2' '' '[Install]' 'WantedBy=multi-user.target' >/etc/systemd/system/ttyd.service
 systemctl daemon-reload
 systemctl enable --now ttyd.service

--- a/lxc/cloud-init/service/ttyd.sh
+++ b/lxc/cloud-init/service/ttyd.sh
@@ -1,0 +1,26 @@
+# pinned: ttyd 1.7.7 from GitHub release
+set -e
+TTYD_VERSION=1.7.7
+
+if [[ ! -x /usr/local/bin/ttyd ]]; then
+  curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" -o /usr/local/bin/ttyd
+  chmod +x /usr/local/bin/ttyd
+fi
+
+cat >/etc/systemd/system/ttyd.service <<'UNIT'
+[Unit]
+Description=ttyd terminal over web
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ttyd -W -p 7681 /bin/bash -l
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now ttyd.service

--- a/lxc/cloud-init/service/vscode-server.sh
+++ b/lxc/cloud-init/service/vscode-server.sh
@@ -2,22 +2,9 @@
 set -e
 CS_VERSION=4.93.1
 DEB_PATH="/tmp/code-server_${CS_VERSION}_amd64.deb"
-
-if ! command -v code-server >/dev/null 2>&1; then
-  curl -fsSL "https://github.com/coder/code-server/releases/download/v${CS_VERSION}/code-server_${CS_VERSION}_amd64.deb" -o "${DEB_PATH}"
-  dpkg -i "${DEB_PATH}"
-fi
-
-if ! id -u ubuntu >/dev/null 2>&1; then
-  useradd -m -s /bin/bash ubuntu
-fi
-
+command -v code-server >/dev/null 2>&1 || (curl -fsSL "https://github.com/coder/code-server/releases/download/v${CS_VERSION}/code-server_${CS_VERSION}_amd64.deb" -o "${DEB_PATH}" && dpkg -i "${DEB_PATH}")
+id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu
 mkdir -p /home/ubuntu/.config/code-server
-cat >/home/ubuntu/.config/code-server/config.yaml <<'CFG'
-bind-addr: 0.0.0.0:8080
-auth: none
-cert: false
-CFG
+printf '%s\n' 'bind-addr: 0.0.0.0:8080' 'auth: none' 'cert: false' >/home/ubuntu/.config/code-server/config.yaml
 chown -R ubuntu:ubuntu /home/ubuntu/.config
-
 systemctl enable --now code-server@ubuntu

--- a/lxc/cloud-init/service/vscode-server.sh
+++ b/lxc/cloud-init/service/vscode-server.sh
@@ -1,0 +1,23 @@
+# pinned: code-server 4.93.1
+set -e
+CS_VERSION=4.93.1
+DEB_PATH="/tmp/code-server_${CS_VERSION}_amd64.deb"
+
+if ! command -v code-server >/dev/null 2>&1; then
+  curl -fsSL "https://github.com/coder/code-server/releases/download/v${CS_VERSION}/code-server_${CS_VERSION}_amd64.deb" -o "${DEB_PATH}"
+  dpkg -i "${DEB_PATH}"
+fi
+
+if ! id -u ubuntu >/dev/null 2>&1; then
+  useradd -m -s /bin/bash ubuntu
+fi
+
+mkdir -p /home/ubuntu/.config/code-server
+cat >/home/ubuntu/.config/code-server/config.yaml <<'CFG'
+bind-addr: 0.0.0.0:8080
+auth: none
+cert: false
+CFG
+chown -R ubuntu:ubuntu /home/ubuntu/.config
+
+systemctl enable --now code-server@ubuntu

--- a/lxc/profiles/service/ttyd.yaml
+++ b/lxc/profiles/service/ttyd.yaml
@@ -1,0 +1,9 @@
+name: service/ttyd
+description: Browser shell service via ttyd
+category: service
+depends:
+  - service/base
+lxd:
+  config: {}
+  devices: {}
+cloud_init: lxc/cloud-init/service/ttyd.sh

--- a/lxc/profiles/service/vscode-server.yaml
+++ b/lxc/profiles/service/vscode-server.yaml
@@ -1,0 +1,9 @@
+name: service/vscode-server
+description: VS Code Server service profile
+category: service
+depends:
+  - service/base
+lxd:
+  config: {}
+  devices: {}
+cloud_init: lxc/cloud-init/service/vscode-server.sh

--- a/lxc/profiles/use-case/dev.yaml
+++ b/lxc/profiles/use-case/dev.yaml
@@ -3,6 +3,8 @@ description: Generic development container
 category: use-case
 depends:
   - service/base
+  - service/vscode-server
+  - service/ttyd
 lxd:
   config: {}
   devices: {}

--- a/scripts/run-mock-server.sh
+++ b/scripts/run-mock-server.sh
@@ -10,6 +10,7 @@ PORT="${YETAOS_PORT:-8000}"
 mkdir -p "${DATA_ROOT}" "${DATA_ROOT}/workspaces" "${DATA_ROOT}/secrets" "${DATA_ROOT}/models"
 
 # Demo mode defaults: local temp data paths and auth disabled unless explicitly set.
+export YETAOS_MOCK_LXD="${YETAOS_MOCK_LXD:-1}"
 export YETAOS_API_KEY="${YETAOS_API_KEY:-}"
 export YETAOS_STORE_PATH="${YETAOS_STORE_PATH:-${DATA_ROOT}/containers.json}"
 export YETAOS_WORKSPACES_DIR="${YETAOS_WORKSPACES_DIR:-${DATA_ROOT}/workspaces}"

--- a/scripts/run-mock-server.sh
+++ b/scripts/run-mock-server.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+DATA_ROOT="${YETAOS_DEMO_ROOT:-/tmp/yetaos}"
+HOST="${YETAOS_HOST:-0.0.0.0}"
+PORT="${YETAOS_PORT:-8000}"
+
+mkdir -p "${DATA_ROOT}" "${DATA_ROOT}/workspaces" "${DATA_ROOT}/secrets" "${DATA_ROOT}/models"
+
+# Demo mode defaults: local temp data paths and auth disabled unless explicitly set.
+export YETAOS_API_KEY="${YETAOS_API_KEY:-}"
+export YETAOS_STORE_PATH="${YETAOS_STORE_PATH:-${DATA_ROOT}/containers.json}"
+export YETAOS_WORKSPACES_DIR="${YETAOS_WORKSPACES_DIR:-${DATA_ROOT}/workspaces}"
+export YETAOS_SECRETS_DIR="${YETAOS_SECRETS_DIR:-${DATA_ROOT}/secrets}"
+export YETAOS_MODELS_DIR="${YETAOS_MODELS_DIR:-${DATA_ROOT}/models}"
+
+cd "${BACKEND_DIR}"
+echo "Starting mock server at http://127.0.0.1:${PORT}/"
+exec uv run uvicorn app.main:app --host "${HOST}" --port "${PORT}"


### PR DESCRIPTION
This PR completes Milestone 4 by delivering end-to-end shell and VS Code proxy support, container detail UI, and workspace export.

What is included:
1. Added per-container proxy routes for shell and code in deploy/Caddyfile.
2. Added service profiles and cloud-init fragments for ttyd and code-server.
3. Implemented container workspace export API and LXD service helper.
4. Added full UI router and HTMX-backed templates/fragments for:
    - dashboard polling
    - create workflow
    - container detail page
    - snapshot actions
    - export/shell/code actions
5. Updated app wiring to include UI routes.
6. Added/updated tests for API export and UI pages.
7. Updated docs/plan checklist to reflect Milestone 4 completion.

Notes:
1. While implementing Milestone 4, missing UI routing/template plumbing (a Milestone 3 dependency) was added to unblock completion.
2. SSE log stream functionality remains out of scope for this PR (Milestone 3 item still open).

Testing performed:
1. uv run python -m pytest tests -q